### PR TITLE
Add github_branch to role meta information

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,8 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
 
+  github_branch: main
+
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Explicitly specify the git branch Ansible Galaxy will use when accessing the repo for this role.

* Related to #1 