### PR TITLE
Add support for Rocky Linux 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,12 @@ jobs:
       fail-fast: true
       matrix:
         distro:
-          - centos:7
-          - centos:8
-          - ubuntu:18.04
-          - ubuntu:20.04
-          - debian:9
-          - debian:10
+          - centos7
+          - centos8
+          - ubuntu1804
+          - ubuntu2004
+          - debian9
+          - debian10
 
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         distro:
           - centos7
-          - centos8
+          - rockylinux8
           - ubuntu1804
           - ubuntu2004
           - debian9

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This Ansible role distributes authorized SSH public keys to users.
 Currently [supported platforms](meta/main.yml) are:
 
 - CentOS 7
-- CentOS 8
+- RockyLinux 8
 - Ubuntu 18.04 LTS
 - Ubuntu 20.04 LTS
 - Debian Stretch

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: jrei/systemd-${MOLECULE_DISTRO:-ubuntu:20.04}
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest
     pre_build_image: true
     privileged: true
     override_command: false


### PR DESCRIPTION
* Replace Centos 8 which is EOL by RockyLinux 8
* Switch to the `geerlingguy/docker-*-ansible:latest` images to be compatible with our other roles.

Closes #18 