### PR TITLE
Remove support for EOL Debian 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           - rockylinux8
           - ubuntu1804
           - ubuntu2004
-          - debian9
           - debian10
 
     steps:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Currently [supported platforms](meta/main.yml) are:
 - RockyLinux 8
 - Ubuntu 18.04 LTS
 - Ubuntu 20.04 LTS
-- Debian Stretch
 - Debian Buster
 
 ## Requirements

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,7 +27,6 @@ galaxy_info:
     - name: "Debian"
       versions:
         - "buster"
-        - "stretch"
 
   galaxy_tags:
     - "ssh"


### PR DESCRIPTION
Debian 9 is end of life and thus I want to remove it from the list of support operating systems.

Closes #40 